### PR TITLE
feat(release): use semantic-release v15

### DIFF
--- a/src/scripts/__tests__/__snapshots__/travis-after-success.js.snap
+++ b/src/scripts/__tests__/__snapshots__/travis-after-success.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`travis-after-success calls concurrently with both scripts 1`] = `concurrently --prefix [{name}] --names codecov,release --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset "echo installing codecov && npx -p codecov -c 'echo running codecov && codecov'" "echo installing semantic-release && npx -p semantic-release@8 -c 'echo running semantic-release && semantic-release pre && npm publish && semantic-release post'"`;
+exports[`travis-after-success adds dry-run flag when not running on master 1`] = `concurrently --prefix [{name}] --names codecov,release --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset "echo installing codecov && npx -p codecov -c 'echo running codecov && codecov'" "echo installing semantic-release && npx -p semantic-release@15 -c 'echo running semantic-release dry run && semantic-release --no-ci --dry-run'"`;
+
+exports[`travis-after-success calls concurrently with both scripts 1`] = `concurrently --prefix [{name}] --names codecov,release --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset "echo installing codecov && npx -p codecov -c 'echo running codecov && codecov'" "echo installing semantic-release && npx -p semantic-release@15 -c 'echo running semantic-release  && semantic-release --no-ci'"`;
 
 exports[`travis-after-success does not do the autorelease script when the version is different 1`] = `concurrently --prefix [{name}] --names codecov --prefix-colors bgBlue.bold.reset "echo installing codecov && npx -p codecov -c 'echo running codecov && codecov'"`;
 
-exports[`travis-after-success does not do the codecov script when there is no coverage directory 1`] = `concurrently --prefix [{name}] --names release --prefix-colors bgBlue.bold.reset "echo installing semantic-release && npx -p semantic-release@8 -c 'echo running semantic-release && semantic-release pre && npm publish && semantic-release post'"`;
+exports[`travis-after-success does not do the codecov script when there is no coverage directory 1`] = `concurrently --prefix [{name}] --names release --prefix-colors bgBlue.bold.reset "echo installing semantic-release && npx -p semantic-release@15 -c 'echo running semantic-release  && semantic-release --no-ci'"`;

--- a/src/scripts/travis-after-success.js
+++ b/src/scripts/travis-after-success.js
@@ -1,7 +1,21 @@
+
 const spawn = require('cross-spawn');
-const { resolveBin, getConcurrentlyArgs, hasFile, pkg } = require('../utils');
+const { resolveBin, getConcurrentlyArgs, hasFile, fromRoot, pkg } = require('../utils');
 
 const autorelease = pkg.version === '0.0.0-semantically-released';
+
+// We don't care about the TravisCI validation
+const releaseConfig = hasFile('release.config.js') ? require(fromRoot('release.config.js')) : {};
+const releaseBranch = releaseConfig.branch || 'master';
+const currentBranch = spawn
+	.sync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+	.stdout.toString()
+	.trim();
+// Run a dry-run release when not on master
+const dryRun = currentBranch !== releaseBranch;
+const releaseFlags = ['--no-ci', dryRun ? '--dry-run' : '']
+	.filter(Boolean)
+	.join(' ');
 
 const result = spawn.sync(
 	resolveBin('concurrently'),
@@ -11,7 +25,7 @@ const result = spawn.sync(
 				? "echo installing codecov && npx -p codecov -c 'echo running codecov && codecov'"
 				: null,
 			release: autorelease
-				? "echo installing semantic-release && npx -p semantic-release@8 -c 'echo running semantic-release && semantic-release pre && npm publish && semantic-release post'"
+				? `echo installing semantic-release && npx -p semantic-release@15 -c 'echo running semantic-release ${dryRun ? 'dry run' : ''} && semantic-release ${releaseFlags}'`
 				: null
 		},
 		{ killOthers: false }


### PR DESCRIPTION
Gives better status messages, easier configuration for custom registries, and
allows outputting expected version bump on PR branches.