### PR TITLE
feat(format): add tsx&jsx to default format config

### DIFF
--- a/src/scripts/__tests__/__snapshots__/format.js.snap
+++ b/src/scripts/__tests__/__snapshots__/format.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`format --config arg can be used for a custom config 1`] = `prettier --ignore-path ./src/config/prettierignore --write **/*.+(js|json|less|css|ts) --config ./my-config.js`;
+exports[`format --config arg can be used for a custom config 1`] = `prettier --ignore-path ./src/config/prettierignore --write **/*.+(js|jsx|json|less|css|ts|tsx) --config ./my-config.js`;
 
-exports[`format --ignore-path arg can be used for a custom ignore file 1`] = `prettier --config ./src/config/prettierrc.js --write **/*.+(js|json|less|css|ts) --ignore-path ./.myignore`;
+exports[`format --ignore-path arg can be used for a custom ignore file 1`] = `prettier --config ./src/config/prettierrc.js --write **/*.+(js|jsx|json|less|css|ts|tsx) --ignore-path ./.myignore`;
 
-exports[`format --no-write prevents --write argument from being added 1`] = `prettier --config ./src/config/prettierrc.js --ignore-path ./src/config/prettierignore **/*.+(js|json|less|css|ts) --no-write`;
+exports[`format --no-write prevents --write argument from being added 1`] = `prettier --config ./src/config/prettierrc.js --ignore-path ./src/config/prettierignore **/*.+(js|jsx|json|less|css|ts|tsx) --no-write`;
 
 exports[`format calls prettier CLI with args 1`] = `prettier --config ./src/config/prettierrc.js --ignore-path ./src/config/prettierignore --write my-src/**/*.js`;

--- a/src/scripts/format.js
+++ b/src/scripts/format.js
@@ -23,7 +23,7 @@ const write = args.includes('--no-write') ? [] : ['--write'];
 // This way the prettierignore will be applied
 const relativeArgs = args.map(a => a.replace(`${process.cwd()}/`, ''));
 
-const filesToApply = parsedArgs._.length ? [] : ['**/*.+(js|json|less|css|ts)'];
+const filesToApply = parsedArgs._.length ? [] : ['**/*.+(js|jsx|json|less|css|ts|tsx)'];
 
 const result = spawn.sync(
 	resolveBin('prettier'),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: default format path match

<!-- Why are these changes necessary? -->
**Why**: not support tsx and jsx default

<!-- How were these changes implemented? -->
**How**: modify config

<!-- Have you done all of these things?  -->
**Checklist**: 
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
