### PR TITLE
feat(exports): added support of exports for package.json

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -28,6 +28,7 @@ Usage: ../ [script] [--flags]
 
 Available Scripts:
   build
+  exports
   format
   lint
   precommit

--- a/src/scripts/exports.js
+++ b/src/scripts/exports.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const currentDir = process.cwd();
+const args = Array.isArray(process.argv) ? process.argv.slice(2) : [];
+const configFile = (args[0] !== 'clean' && args[0]) || 'package.json';
+const config = JSON.parse(fs.readFileSync(path.join(currentDir, configFile)).toString());
+
+const clean = () =>
+	Object.keys(config.exports).forEach(alias => {
+		const aliasFile = path.join(currentDir, alias);
+		fs.existsSync(aliasFile) && fs.unlinkSync(aliasFile);
+	});
+
+const linkExports = () => {
+	Object.keys(config.exports).forEach(alias => {
+		const aliasFile = path.join(currentDir, alias);
+
+		try {
+			require.resolve(config.exports[alias], { paths: [currentDir] });
+			fs.writeFileSync(
+				path.join(aliasFile),
+				`module.exports = require('${config.exports[alias]}');`
+			);
+		} catch (e) {
+			console.error(
+				`Error: Cannot alias '${alias}' target '${config.exports[alias]}' from '${configFile}' exports\n`
+			);
+			process.exitCode = 1;
+		}
+	});
+
+	if (process.exitCode === 1) {
+		clean();
+	}
+};
+
+if (config.exports && config.exports instanceof Object) {
+	args[0] === 'clean' ? clean() : linkExports();
+}


### PR DESCRIPTION
Package Exports
 Custom subpath aliasing and encapsulation can be provided through the "exports" field.
```
// ./node_modules/es-module-package/package.json
{
  "exports": {
    "./submodule": "./src/submodule.js"
  }
}
```
`tradeshift-scripts exports` to build files.
`tradeshift-scripts exports clean` to clean builded files.
`tradeshift-scripts exports filename.json` to build files from confing `filename.json`