### PR TITLE
Dependency bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"eslint": "^7.9.0",
 		"eslint-config-tradeshift": "^7.0.0",
 		"eslint-plugin-react": "^7.16.0",
-		"execa": "^4.0.3",
+		"execa": "^5.0.0",
 		"glob": "^7.1.2",
 		"husky": "^4.3.0",
 		"jest": "^26.4.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"babel-plugin-transform-inline-environment-variables": "^0.4.3",
 		"babel-plugin-transform-react-remove-prop-types": "^0.4.24",
 		"browserslist": "^4.7.2",
-		"concurrently": "^5.0.0",
+		"concurrently": "^6.1.0",
 		"cross-env": "^7.0.2",
 		"cross-spawn": "^7.0.1",
 		"doctoc": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"husky": "^4.3.0",
 		"jest": "^26.4.2",
 		"jest-junit": "^12.0.0",
-		"lint-staged": "^10.4.0",
+		"lint-staged": "^11.0.0",
 		"lodash.camelcase": "^4.3.0",
 		"lodash.has": "^4.5.2",
 		"lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"concurrently": "^5.0.0",
 		"cross-env": "^7.0.2",
 		"cross-spawn": "^7.0.1",
-		"doctoc": "^1.4.0",
+		"doctoc": "^2.0.0",
 		"env-ci": "^5.0.2",
 		"eslint": "^7.9.0",
 		"eslint-config-tradeshift": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"glob": "^7.1.2",
 		"husky": "^4.3.0",
 		"jest": "^26.4.2",
-		"jest-junit": "^11.1.0",
+		"jest-junit": "^12.0.0",
 		"lint-staged": "^10.4.0",
 		"lodash.camelcase": "^4.3.0",
 		"lodash.has": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"arrify": "^2.0.1",
 		"babel-jest": "^26.3.0",
 		"babel-plugin-dynamic-import-node": "^2.3.0",
-		"babel-plugin-macros": "^2.6.1",
+		"babel-plugin-macros": "^3.1.0",
 		"babel-plugin-minify-dead-code-elimination": "^0.5.1",
 		"babel-plugin-module-resolver": "^4.0.0",
 		"babel-plugin-transform-inline-environment-variables": "^0.4.3",


### PR DESCRIPTION
- fix(deps): bump doctoc from 1.4.0 to 2.0.0
- fix(deps): bump concurrently to v6.1.0
- fix(deps): bump execa to v5.0.0
- fix(deps): bump jest-junit to v12.0.0
- fix(deps): update lint-staged to v11.0.0
- fix(deps): bump babel-plugin-macros to v3.1.0
