### PR TITLE
fix(deps): move doctoc to peerDependencies due to CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,12 +1830,14 @@
 		"@textlint/ast-node-types": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.4.3.tgz",
-			"integrity": "sha512-qi2jjgO6Tn3KNPGnm6B7p6QTEPvY95NFsIAaJuwbulur8iJUEenp1OnoUfiDaC/g2WPPEFkcfXpmnu8XEMFo2A=="
+			"integrity": "sha512-qi2jjgO6Tn3KNPGnm6B7p6QTEPvY95NFsIAaJuwbulur8iJUEenp1OnoUfiDaC/g2WPPEFkcfXpmnu8XEMFo2A==",
+			"dev": true
 		},
 		"@textlint/markdown-to-ast": {
 			"version": "6.1.7",
 			"resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.7.tgz",
 			"integrity": "sha512-B0QtokeQR4a9+4q0NQr8T9l7A1fFihTN5Ze57tVgqW+3ymzXEouh8DvPHeNQ4T6jEkAThvdjk95mxAMpGRJ79w==",
+			"dev": true,
 			"requires": {
 				"@textlint/ast-node-types": "^4.2.5",
 				"debug": "^4.1.1",
@@ -1850,6 +1852,7 @@
 					"version": "4.3.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
 					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -1857,7 +1860,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -2149,6 +2153,7 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
 			"integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
+			"dev": true,
 			"requires": {
 				"emoji-regex": "~6.1.0"
 			},
@@ -2156,7 +2161,8 @@
 				"emoji-regex": {
 					"version": "6.1.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
-					"integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI="
+					"integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=",
+					"dev": true
 				}
 			}
 		},
@@ -2585,7 +2591,8 @@
 		"bail": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -2659,7 +2666,8 @@
 		"boundary": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
-			"integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI="
+			"integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=",
+			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -2798,17 +2806,20 @@
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+			"dev": true
 		},
 		"character-entities-legacy": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+			"dev": true
 		},
 		"character-reference-invalid": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "3.5.1",
@@ -3013,7 +3024,8 @@
 		"collapse-white-space": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
+			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+			"dev": true
 		},
 		"collect-v8-coverage": {
 			"version": "1.0.1",
@@ -3412,6 +3424,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.0.0.tgz",
 			"integrity": "sha512-thvCndtwVPe3GCDUG09NYPu9D72Ons3MFh/Fe5A3bePMHGa1XSMgJWyL04bkxa0DyyaylEB2UrqigbQM0fcj7w==",
+			"dev": true,
 			"requires": {
 				"@textlint/markdown-to-ast": "~6.1.7",
 				"anchor-markdown-header": "~0.5.7",
@@ -3433,6 +3446,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
 			"integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
 				"domhandler": "^4.2.0",
@@ -3443,6 +3457,7 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
 					"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+					"dev": true,
 					"requires": {
 						"domelementtype": "^2.2.0"
 					}
@@ -3452,7 +3467,8 @@
 		"domelementtype": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-			"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+			"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+			"dev": true
 		},
 		"domexception": {
 			"version": "2.0.1",
@@ -3473,6 +3489,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
 			"integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1"
 			}
@@ -3481,6 +3498,7 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
 			"integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+			"dev": true,
 			"requires": {
 				"dom-serializer": "^1.0.1",
 				"domelementtype": "^2.2.0",
@@ -3491,6 +3509,7 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
 					"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+					"dev": true,
 					"requires": {
 						"domelementtype": "^2.2.0"
 					}
@@ -3540,7 +3559,8 @@
 		"entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true
 		},
 		"env-ci": {
 			"version": "5.0.2",
@@ -4497,6 +4517,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
 			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"dev": true,
 			"requires": {
 				"format": "^0.2.0"
 			}
@@ -4621,7 +4642,8 @@
 		"format": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+			"dev": true
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -4929,6 +4951,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
 			"integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
 				"domhandler": "^3.0.0",
@@ -5162,12 +5185,14 @@
 		"is-alphabetical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+			"dev": true
 		},
 		"is-alphanumerical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
 			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -5252,7 +5277,8 @@
 		"is-decimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -5308,7 +5334,8 @@
 		"is-hexadecimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+			"dev": true
 		},
 		"is-negative-zero": {
 			"version": "2.0.1",
@@ -5346,7 +5373,8 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -5406,7 +5434,8 @@
 		"is-whitespace-character": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -5416,7 +5445,8 @@
 		"is-word-character": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
+			"dev": true
 		},
 		"is-wsl": {
 			"version": "2.2.0",
@@ -7526,7 +7556,8 @@
 		"markdown-escapes": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+			"dev": true
 		},
 		"merge-stream": {
 			"version": "2.0.0",
@@ -7920,6 +7951,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
 			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
@@ -8379,6 +8411,7 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
 			"integrity": "sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==",
+			"dev": true,
 			"requires": {
 				"fault": "^1.0.1",
 				"xtend": "^4.0.1"
@@ -8388,6 +8421,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
 			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"dev": true,
 			"requires": {
 				"collapse-white-space": "^1.0.2",
 				"is-alphabetical": "^1.0.0",
@@ -8424,7 +8458,8 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.2",
@@ -9012,7 +9047,8 @@
 		"state-toggle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+			"dev": true
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -9144,6 +9180,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
 			"integrity": "sha1-3YAkJeD1PcSm56yjdSkBoczaevU=",
+			"dev": true,
 			"requires": {
 				"boundary": "^1.0.1"
 			}
@@ -9319,7 +9356,8 @@
 		"traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+			"dev": true
 		},
 		"tree-kill": {
 			"version": "1.2.2",
@@ -9329,17 +9367,20 @@
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+			"dev": true
 		},
 		"trim-trailing-lines": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ=="
+			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
+			"dev": true
 		},
 		"trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+			"dev": true
 		},
 		"tsconfig-paths": {
 			"version": "3.9.0",
@@ -9434,12 +9475,14 @@
 		"underscore": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-			"integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+			"integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+			"dev": true
 		},
 		"unherit": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
 			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.0",
 				"xtend": "^4.0.0"
@@ -9473,6 +9516,7 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
 			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
 				"extend": "^3.0.0",
@@ -9496,12 +9540,14 @@
 		"unist-util-is": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+			"dev": true
 		},
 		"unist-util-remove-position": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
 			"integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
 			}
@@ -9509,12 +9555,14 @@
 		"unist-util-stringify-position": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+			"dev": true
 		},
 		"unist-util-visit": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
 			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+			"dev": true,
 			"requires": {
 				"unist-util-visit-parents": "^2.0.0"
 			}
@@ -9523,6 +9571,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
 			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+			"dev": true,
 			"requires": {
 				"unist-util-is": "^3.0.0"
 			}
@@ -9577,7 +9626,8 @@
 		"update-section": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
-			"integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg="
+			"integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.4.1",
@@ -9653,6 +9703,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
 			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.4",
 				"replace-ext": "1.0.0",
@@ -9663,12 +9714,14 @@
 		"vfile-location": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+			"dev": true
 		},
 		"vfile-message": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
 			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"dev": true,
 			"requires": {
 				"unist-util-stringify-position": "^1.1.1"
 			}
@@ -9854,7 +9907,8 @@
 		"x-is-string": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+			"dev": true
 		},
 		"xml": {
 			"version": "1.0.1",
@@ -9874,7 +9928,8 @@
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"concurrently": "^6.1.0",
 		"cross-env": "^7.0.2",
 		"cross-spawn": "^7.0.1",
-		"doctoc": "^2.0.0",
 		"env-ci": "^5.0.2",
 		"eslint": "^7.9.0",
 		"eslint-config-tradeshift": "^7.0.0",
@@ -78,6 +77,14 @@
 		"which": "^2.0.1",
 		"yargs-parser": "^20.2.0"
 	},
+	"peerDependencies": {
+		"doctoc": "^2.0.0"
+	},
+	"devDependencies": {
+		"doctoc": "^2.0.0",
+		"jest-in-case": "^1.0.2",
+		"typescript": "^4.0.3"
+	},
 	"eslintIgnored": [
 		"node_modules",
 		"coverage",
@@ -96,9 +103,5 @@
 	"bugs": {
 		"url": "https://github.com/wejendorp/tradeshift-scripts/issues"
 	},
-	"homepage": "https://github.com/wejendorp/tradeshift-scripts#readme",
-	"devDependencies": {
-		"jest-in-case": "^1.0.2",
-		"typescript": "^4.0.3"
-	}
+	"homepage": "https://github.com/wejendorp/tradeshift-scripts#readme"
 }

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,7 +1,7 @@
-const { resolveKcdScripts, resolveBin } = require('../utils');
+const { resolveKcdScripts, resolveBin, ifAnyDep } = require('../utils');
 
 const kcdScripts = resolveKcdScripts();
-const doctoc = resolveBin('doctoc');
+const doctoc = ifAnyDep('doctoc') ? resolveBin('doctoc') : false;
 
 module.exports = {
 	'**/*.+(js|jsx|json|less|css|ts|tsx)': [
@@ -9,5 +9,5 @@ module.exports = {
 		`${kcdScripts} lint`,
 		`${kcdScripts} test --findRelatedTests`,
 	],
-	'README.md': [`${doctoc} --maxlevel 2 --notitle`],
+	'README.md': doctoc ? [`${doctoc} --maxlevel 2 --notitle`] : [],
 };


### PR DESCRIPTION
underscore vuln, from doctoc deps: CVE-2021-23358
trim vuln, from doctoc deps: CVE-2020-7753

This change allows repos to install doctoc only if they feel they need
it, and allows using ts-scripts without imposing vulns in the dependency
tree.
