### PR TITLE
fix: 🐛 bump eslint-config-tradeshift from 7.0.0 to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "tradeshift-scripts",
 			"version": "0.0.0-semantically-released",
 			"license": "MIT",
 			"dependencies": {
@@ -35,7 +34,7 @@
 				"cross-spawn": "^7.0.1",
 				"env-ci": "^7.0.0",
 				"eslint": "^7.9.0",
-				"eslint-config-tradeshift": "^7.0.0",
+				"eslint-config-tradeshift": "^7.1.0",
 				"eslint-plugin-react": "^7.16.0",
 				"execa": "^5.0.0",
 				"glob": "^7.1.2",
@@ -2691,6 +2690,8 @@
 			"version": "4.33.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
 			"integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/experimental-utils": "4.33.0",
 				"@typescript-eslint/scope-manager": "4.33.0",
@@ -2722,6 +2723,8 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
 			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -2770,6 +2773,8 @@
 			"version": "4.33.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
 			"integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "4.33.0",
 				"@typescript-eslint/types": "4.33.0",
@@ -4515,12 +4520,12 @@
 			}
 		},
 		"node_modules/eslint-config-tradeshift": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-7.0.0.tgz",
-			"integrity": "sha512-+gtN0JN8sOKV27V0kRv0mB/56UY7afe1J/i6TqFFD16LsbeHdyOv/acGLyfGF1QDN0Z/Rx0n/M+Bx83iz5BPzg==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-7.1.0.tgz",
+			"integrity": "sha512-Tky1v74rWC5sGBGH7fLvLUV3fQWQtlTSOcaInH9aCrbx+HVbbXv9zNcrabkJLP5Ir8v7zfFhicOveJkKSh8Xqw==",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "^4.2.0",
-				"@typescript-eslint/parser": "^4.2.0",
+				"@typescript-eslint/eslint-plugin": "^5.12.0",
+				"@typescript-eslint/parser": "^5.12.0",
 				"babel-eslint": "^10.0.3",
 				"eslint-config-prettier": "^6.5.0",
 				"eslint-config-standard": "^14.1.0",
@@ -4531,7 +4536,224 @@
 				"eslint-plugin-standard": "^4.0.1"
 			},
 			"peerDependencies": {
-				"eslint": "^7"
+				"eslint": "^7 || ^8"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
+			"integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "5.13.0",
+				"@typescript-eslint/type-utils": "5.13.0",
+				"@typescript-eslint/utils": "5.13.0",
+				"debug": "^4.3.2",
+				"functional-red-black-tree": "^1.0.1",
+				"ignore": "^5.1.8",
+				"regexpp": "^3.2.0",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
+			"integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+			"dependencies": {
+				"@typescript-eslint/utils": "5.13.0",
+				"debug": "^4.3.2",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
+			"integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"@typescript-eslint/scope-manager": "5.13.0",
+				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/typescript-estree": "5.13.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/parser": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
+			"integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "5.13.0",
+				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/typescript-estree": "5.13.0",
+				"debug": "^4.3.2"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
+			"integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/visitor-keys": "5.13.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/types": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
+			"integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
+			"integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/visitor-keys": "5.13.0",
+				"debug": "^4.3.2",
+				"globby": "^11.0.4",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
+			"integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.13.0",
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-config-tradeshift/node_modules/ignore": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
@@ -12446,6 +12668,8 @@
 			"version": "4.33.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
 			"integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"@typescript-eslint/experimental-utils": "4.33.0",
 				"@typescript-eslint/scope-manager": "4.33.0",
@@ -12460,7 +12684,9 @@
 				"ignore": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -12491,6 +12717,8 @@
 			"version": "4.33.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
 			"integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"@typescript-eslint/scope-manager": "4.33.0",
 				"@typescript-eslint/types": "4.33.0",
@@ -13819,12 +14047,12 @@
 			"requires": {}
 		},
 		"eslint-config-tradeshift": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-7.0.0.tgz",
-			"integrity": "sha512-+gtN0JN8sOKV27V0kRv0mB/56UY7afe1J/i6TqFFD16LsbeHdyOv/acGLyfGF1QDN0Z/Rx0n/M+Bx83iz5BPzg==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-7.1.0.tgz",
+			"integrity": "sha512-Tky1v74rWC5sGBGH7fLvLUV3fQWQtlTSOcaInH9aCrbx+HVbbXv9zNcrabkJLP5Ir8v7zfFhicOveJkKSh8Xqw==",
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "^4.2.0",
-				"@typescript-eslint/parser": "^4.2.0",
+				"@typescript-eslint/eslint-plugin": "^5.12.0",
+				"@typescript-eslint/parser": "^5.12.0",
 				"babel-eslint": "^10.0.3",
 				"eslint-config-prettier": "^6.5.0",
 				"eslint-config-standard": "^14.1.0",
@@ -13833,6 +14061,122 @@
 				"eslint-plugin-node": "^11.1.0",
 				"eslint-plugin-promise": "^4.2.1",
 				"eslint-plugin-standard": "^4.0.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": {
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
+					"integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+					"requires": {
+						"@typescript-eslint/scope-manager": "5.13.0",
+						"@typescript-eslint/type-utils": "5.13.0",
+						"@typescript-eslint/utils": "5.13.0",
+						"debug": "^4.3.2",
+						"functional-red-black-tree": "^1.0.1",
+						"ignore": "^5.1.8",
+						"regexpp": "^3.2.0",
+						"semver": "^7.3.5",
+						"tsutils": "^3.21.0"
+					},
+					"dependencies": {
+						"@typescript-eslint/type-utils": {
+							"version": "5.13.0",
+							"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
+							"integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+							"requires": {
+								"@typescript-eslint/utils": "5.13.0",
+								"debug": "^4.3.2",
+								"tsutils": "^3.21.0"
+							}
+						},
+						"@typescript-eslint/utils": {
+							"version": "5.13.0",
+							"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
+							"integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+							"requires": {
+								"@types/json-schema": "^7.0.9",
+								"@typescript-eslint/scope-manager": "5.13.0",
+								"@typescript-eslint/types": "5.13.0",
+								"@typescript-eslint/typescript-estree": "5.13.0",
+								"eslint-scope": "^5.1.1",
+								"eslint-utils": "^3.0.0"
+							},
+							"dependencies": {
+								"eslint-utils": {
+									"version": "3.0.0",
+									"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+									"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+									"requires": {
+										"eslint-visitor-keys": "^2.0.0"
+									}
+								}
+							}
+						},
+						"eslint-visitor-keys": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+							"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+						}
+					}
+				},
+				"@typescript-eslint/parser": {
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
+					"integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+					"requires": {
+						"@typescript-eslint/scope-manager": "5.13.0",
+						"@typescript-eslint/types": "5.13.0",
+						"@typescript-eslint/typescript-estree": "5.13.0",
+						"debug": "^4.3.2"
+					}
+				},
+				"@typescript-eslint/scope-manager": {
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
+					"integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+					"requires": {
+						"@typescript-eslint/types": "5.13.0",
+						"@typescript-eslint/visitor-keys": "5.13.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
+					"integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg=="
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
+					"integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+					"requires": {
+						"@typescript-eslint/types": "5.13.0",
+						"@typescript-eslint/visitor-keys": "5.13.0",
+						"debug": "^4.3.2",
+						"globby": "^11.0.4",
+						"is-glob": "^4.0.3",
+						"semver": "^7.3.5",
+						"tsutils": "^3.21.0"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
+					"integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+					"requires": {
+						"@typescript-eslint/types": "5.13.0",
+						"eslint-visitor-keys": "^3.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+				},
+				"ignore": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+				}
 			}
 		},
 		"eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"cross-spawn": "^7.0.1",
 		"env-ci": "^7.0.0",
 		"eslint": "^7.9.0",
-		"eslint-config-tradeshift": "^7.0.0",
+		"eslint-config-tradeshift": "^7.1.0",
 		"eslint-plugin-react": "^7.16.0",
 		"execa": "^5.0.0",
 		"glob": "^7.1.2",


### PR DESCRIPTION
Update eslint-config-tradeshift so that eslint can be updated to version
8 on repos using tradeshift scripts.

✅ Closes: FP-1420

**What**: Update eslint-config-tradeshift to 7.1.0

**Why**: This is to allow repos using tradeshift-scripts to upgrade eslint from v7 to v8

**How**: Ran `npm install` after updating the eslint-config-tradeshift version to 7.1.0

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
