### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3605,12 +3605,12 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
 		},
 		"node_modules/browserslist": {
-			"version": "4.19.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-			"integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+			"version": "4.20.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+			"integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001312",
-				"electron-to-chromium": "^1.4.71",
+				"caniuse-lite": "^1.0.30001313",
+				"electron-to-chromium": "^1.4.76",
 				"escalade": "^3.1.1",
 				"node-releases": "^2.0.2",
 				"picocolors": "^1.0.0"
@@ -3668,9 +3668,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001312",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+			"version": "1.0.30001313",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+			"integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -4316,9 +4316,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.75",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-			"integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q=="
+			"version": "1.4.76",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+			"integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -4844,9 +4844,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
-			"integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
+			"integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
 			"dependencies": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flatmap": "^1.2.5",
@@ -10115,9 +10115,9 @@
 			}
 		},
 		"node_modules/tsconfig-paths": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-			"integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz",
+			"integrity": "sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==",
 			"dependencies": {
 				"@types/json5": "^0.0.29",
 				"json5": "^1.0.1",
@@ -13206,12 +13206,12 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
 		},
 		"browserslist": {
-			"version": "4.19.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-			"integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+			"version": "4.20.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+			"integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001312",
-				"electron-to-chromium": "^1.4.71",
+				"caniuse-lite": "^1.0.30001313",
+				"electron-to-chromium": "^1.4.76",
 				"escalade": "^3.1.1",
 				"node-releases": "^2.0.2",
 				"picocolors": "^1.0.0"
@@ -13250,9 +13250,9 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001312",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+			"version": "1.0.30001313",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+			"integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q=="
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -13717,9 +13717,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.75",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-			"integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q=="
+			"version": "1.4.76",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+			"integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA=="
 		},
 		"emittery": {
 			"version": "0.8.1",
@@ -14182,9 +14182,9 @@
 			"integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ=="
 		},
 		"eslint-plugin-react": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
-			"integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
+			"integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
 			"requires": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flatmap": "^1.2.5",
@@ -17911,9 +17911,9 @@
 			"dev": true
 		},
 		"tsconfig-paths": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-			"integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz",
+			"integrity": "sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==",
 			"requires": {
 				"@types/json5": "^0.0.29",
 				"json5": "^1.0.1",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._