### PR TITLE
fix: 🐛 bump eslint-config-tradeshift from 7.1.0 to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"cross-spawn": "^7.0.1",
 				"env-ci": "^7.0.0",
 				"eslint": "^7.9.0",
-				"eslint-config-tradeshift": "^7.1.0",
+				"eslint-config-tradeshift": "^8.0.0",
 				"eslint-plugin-react": "^7.16.0",
 				"execa": "^5.0.0",
 				"glob": "^7.1.2",
@@ -2699,13 +2699,13 @@
 			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
-			"integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+			"integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/type-utils": "5.13.0",
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/type-utils": "5.14.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -2738,124 +2738,14 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-			"integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
-			"dependencies": {
-				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.33.0",
-				"@typescript-eslint/types": "4.33.0",
-				"@typescript-eslint/typescript-estree": "4.33.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "*"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-			"integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-			"dependencies": {
-				"@typescript-eslint/types": "4.33.0",
-				"@typescript-eslint/visitor-keys": "4.33.0"
-			},
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-			"integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-			"integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-			"dependencies": {
-				"@typescript-eslint/types": "4.33.0",
-				"@typescript-eslint/visitor-keys": "4.33.0",
-				"debug": "^4.3.1",
-				"globby": "^11.0.3",
-				"is-glob": "^4.0.1",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-			"integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-			"dependencies": {
-				"@typescript-eslint/types": "4.33.0",
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-			"integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+			"integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"debug": "^4.3.2"
 			},
 			"engines": {
@@ -2875,12 +2765,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-			"integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+			"integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0"
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2891,11 +2781,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
-			"integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+			"integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
 			"dependencies": {
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
@@ -2916,9 +2806,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-			"integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+			"integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -2928,12 +2818,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-			"integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+			"integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -2954,14 +2844,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
-			"integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+			"integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -2994,11 +2884,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-			"integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+			"integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"engines": {
@@ -4577,46 +4467,56 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-			"integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
-			"dependencies": {
-				"get-stdin": "^6.0.0"
-			},
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
 			"bin": {
-				"eslint-config-prettier-check": "bin/cli.js"
+				"eslint-config-prettier": "bin/cli.js"
 			},
 			"peerDependencies": {
-				"eslint": ">=3.14.1"
+				"eslint": ">=7.0.0"
 			}
 		},
 		"node_modules/eslint-config-standard": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-			"integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+			"integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
 			"peerDependencies": {
-				"eslint": ">=6.2.2",
-				"eslint-plugin-import": ">=2.18.0",
-				"eslint-plugin-node": ">=9.1.0",
-				"eslint-plugin-promise": ">=4.2.1",
-				"eslint-plugin-standard": ">=4.0.0"
+				"eslint": "^7.12.1",
+				"eslint-plugin-import": "^2.22.1",
+				"eslint-plugin-node": "^11.1.0",
+				"eslint-plugin-promise": "^4.2.1 || ^5.0.0"
 			}
 		},
 		"node_modules/eslint-config-tradeshift": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-7.1.0.tgz",
-			"integrity": "sha512-Tky1v74rWC5sGBGH7fLvLUV3fQWQtlTSOcaInH9aCrbx+HVbbXv9zNcrabkJLP5Ir8v7zfFhicOveJkKSh8Xqw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-8.0.0.tgz",
+			"integrity": "sha512-QwbzfpwLXqfRgQza4Jlp/sZWPCp1K3aFqfNeS9xax56JjLPUPyuG0cR+ajo3ZRWCwBljpPDQG5NCG95QLQmlBg==",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.12.0",
-				"@typescript-eslint/parser": "^5.12.0",
-				"babel-eslint": "^10.0.3",
-				"eslint-config-prettier": "^6.5.0",
-				"eslint-config-standard": "^14.1.0",
-				"eslint-plugin-import": "^2.18.2",
-				"eslint-plugin-jest": "^24.0.2",
+				"@typescript-eslint/eslint-plugin": "^5.14.0",
+				"@typescript-eslint/parser": "^5.14.0",
+				"babel-eslint": "^10.1.0",
+				"eslint-config-prettier": "^8.5.0",
+				"eslint-config-standard": "^16.0.3",
+				"eslint-plugin-import": "^2.25.4",
+				"eslint-plugin-jest": "^26.1.1",
 				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-promise": "^4.2.1",
-				"eslint-plugin-standard": "^4.0.1"
+				"eslint-plugin-promise": "^5.0.0",
+				"eslint-plugin-standard": "^5.0.0"
 			},
 			"peerDependencies": {
 				"eslint": "^7 || ^8"
@@ -4781,21 +4681,24 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "24.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
-			"integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
+			"integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
 			"dependencies": {
-				"@typescript-eslint/experimental-utils": "^4.0.1"
+				"@typescript-eslint/utils": "^5.10.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": ">= 4",
-				"eslint": ">=5"
+				"@typescript-eslint/eslint-plugin": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@typescript-eslint/eslint-plugin": {
+					"optional": true
+				},
+				"jest": {
 					"optional": true
 				}
 			}
@@ -4836,11 +4739,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-promise": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-			"integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
+			"integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
 			"engines": {
-				"node": ">=6"
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-react": {
@@ -4902,9 +4808,10 @@
 			}
 		},
 		"node_modules/eslint-plugin-standard": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-			"integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
+			"integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
+			"deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
 			"funding": [
 				{
 					"type": "github",
@@ -5468,14 +5375,6 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/get-stdin": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -12592,13 +12491,13 @@
 			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
-			"integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+			"integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/type-utils": "5.13.0",
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/type-utils": "5.14.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -12614,108 +12513,48 @@
 				}
 			}
 		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-			"integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
-			"requires": {
-				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.33.0",
-				"@typescript-eslint/types": "4.33.0",
-				"@typescript-eslint/typescript-estree": "4.33.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
-			},
-			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-					"integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/visitor-keys": "4.33.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-					"integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-					"integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/visitor-keys": "4.33.0",
-						"debug": "^4.3.1",
-						"globby": "^11.0.3",
-						"is-glob": "^4.0.1",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-					"integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				},
-				"eslint-utils": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-					"requires": {
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
-			}
-		},
 		"@typescript-eslint/parser": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-			"integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+			"integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"debug": "^4.3.2"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-			"integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+			"integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
 			"requires": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0"
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
-			"integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+			"integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
 			"requires": {
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-			"integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg=="
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+			"integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw=="
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-			"integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+			"integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
 			"requires": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -12724,14 +12563,14 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
-			"integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+			"integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -12747,11 +12586,11 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-			"integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+			"integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
 			"requires": {
-				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"dependencies": {
@@ -13985,34 +13824,32 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-			"integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
-			"requires": {
-				"get-stdin": "^6.0.0"
-			}
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+			"requires": {}
 		},
 		"eslint-config-standard": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-			"integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+			"integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
 			"requires": {}
 		},
 		"eslint-config-tradeshift": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-7.1.0.tgz",
-			"integrity": "sha512-Tky1v74rWC5sGBGH7fLvLUV3fQWQtlTSOcaInH9aCrbx+HVbbXv9zNcrabkJLP5Ir8v7zfFhicOveJkKSh8Xqw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-tradeshift/-/eslint-config-tradeshift-8.0.0.tgz",
+			"integrity": "sha512-QwbzfpwLXqfRgQza4Jlp/sZWPCp1K3aFqfNeS9xax56JjLPUPyuG0cR+ajo3ZRWCwBljpPDQG5NCG95QLQmlBg==",
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "^5.12.0",
-				"@typescript-eslint/parser": "^5.12.0",
-				"babel-eslint": "^10.0.3",
-				"eslint-config-prettier": "^6.5.0",
-				"eslint-config-standard": "^14.1.0",
-				"eslint-plugin-import": "^2.18.2",
-				"eslint-plugin-jest": "^24.0.2",
+				"@typescript-eslint/eslint-plugin": "^5.14.0",
+				"@typescript-eslint/parser": "^5.14.0",
+				"babel-eslint": "^10.1.0",
+				"eslint-config-prettier": "^8.5.0",
+				"eslint-config-standard": "^16.0.3",
+				"eslint-plugin-import": "^2.25.4",
+				"eslint-plugin-jest": "^26.1.1",
 				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-promise": "^4.2.1",
-				"eslint-plugin-standard": "^4.0.1"
+				"eslint-plugin-promise": "^5.0.0",
+				"eslint-plugin-standard": "^5.0.0"
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -14144,11 +13981,11 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "24.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
-			"integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
+			"integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^4.0.1"
+				"@typescript-eslint/utils": "^5.10.0"
 			}
 		},
 		"eslint-plugin-node": {
@@ -14177,9 +14014,10 @@
 			}
 		},
 		"eslint-plugin-promise": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-			"integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
+			"integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
+			"requires": {}
 		},
 		"eslint-plugin-react": {
 			"version": "7.29.3",
@@ -14227,9 +14065,9 @@
 			}
 		},
 		"eslint-plugin-standard": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-			"integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
+			"integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
 			"requires": {}
 		},
 		"eslint-scope": {
@@ -14552,11 +14390,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
-		},
-		"get-stdin": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
 		},
 		"get-stream": {
 			"version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"cross-spawn": "^7.0.1",
 		"env-ci": "^7.0.0",
 		"eslint": "^7.9.0",
-		"eslint-config-tradeshift": "^7.1.0",
+		"eslint-config-tradeshift": "^8.0.0",
 		"eslint-plugin-react": "^7.16.0",
 		"execa": "^5.0.0",
 		"glob": "^7.1.2",


### PR DESCRIPTION
Update eslint-config-tradeshift so that eslint can be updated to version
8 on repos using Tradeshift Scripts.

✅ Closes: FP-1420

**What**: Update eslint-config-tradeshift to 8.0.0

**Why**: This is to allow repos using tradeshift-scripts to upgrade eslint from v7 to v8

**How**: Ran npm install after updating the eslint-config-tradeshift version to 8.0.0

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
