### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,17 +127,17 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.7.tgz",
-			"integrity": "sha512-djHlEfFHnSnTAcPb7dATbiM5HxGOP98+3JLBZtjRb5I7RXrw7kFRoG2dXM8cm3H+o11A8IFH/uprmJpwFynRNQ==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+			"integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.17.7",
 				"@babel/helper-compilation-targets": "^7.17.7",
 				"@babel/helper-module-transforms": "^7.17.7",
-				"@babel/helpers": "^7.17.7",
-				"@babel/parser": "^7.17.7",
+				"@babel/helpers": "^7.17.8",
+				"@babel/parser": "^7.17.8",
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.17.3",
 				"@babel/types": "^7.17.0",
@@ -546,9 +546,9 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.7.tgz",
-			"integrity": "sha512-TKsj9NkjJfTBxM7Phfy7kv6yYc4ZcOo+AaWGqQOKTPDOmcGkIFb5xNA746eKisQkm4yavUYh4InYM9S+VnO01w==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+			"integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
 			"dependencies": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.17.3",
@@ -572,9 +572,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
-			"integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+			"integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1301,12 +1301,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
-			"integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz",
+			"integrity": "sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==",
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.16.7",
-				"@babel/helper-module-transforms": "^7.16.7",
+				"@babel/helper-module-transforms": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
@@ -1782,9 +1782,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-			"integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+			"integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -2654,9 +2654,9 @@
 			}
 		},
 		"node_modules/@types/babel__core": {
-			"version": "7.1.18",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
-			"integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
+			"version": "7.1.19",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
+			"integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -3603,13 +3603,19 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001317",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz",
-			"integrity": "sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
+			"version": "1.0.30001319",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+			"integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				}
+			]
 		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
@@ -4034,9 +4040,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -4161,9 +4167,9 @@
 			}
 		},
 		"node_modules/dom-serializer/node_modules/domhandler": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-			"integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
 			"dev": true,
 			"dependencies": {
 				"domelementtype": "^2.2.0"
@@ -4236,9 +4242,9 @@
 			}
 		},
 		"node_modules/domutils/node_modules/domhandler": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-			"integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
 			"dev": true,
 			"dependencies": {
 				"domelementtype": "^2.2.0"
@@ -4251,9 +4257,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.86",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.86.tgz",
-			"integrity": "sha512-EVTZ+igi8x63pK4bPuA95PXIs2b2Cowi3WQwI9f9qManLiZJOD1Lash1J3W4TvvcUCcIR4o/rgi9o8UicXSO+w=="
+			"version": "1.4.88",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz",
+			"integrity": "sha512-oA7mzccefkvTNi9u7DXmT0LqvhnOiN2BhSrKerta7HeUC1cLoIwtbf2wL+Ah2ozh5KQd3/1njrGrwDBXx6d14Q=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -4743,9 +4749,9 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "26.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
-			"integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.2.tgz",
+			"integrity": "sha512-1bXCoRODPkGN06n9KAMls4Jm0eyS+0Q/LWcIxhqWR2ycV0Z7lnx2c10idk4dtFIJY5xStgiIr5snC6/rxcXpbw==",
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -9646,17 +9652,17 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"node_modules/string.prototype.matchall": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
-			"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+			"integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
-				"has-symbols": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"regexp.prototype.flags": "^1.3.1",
+				"regexp.prototype.flags": "^1.4.1",
 				"side-channel": "^1.0.4"
 			},
 			"funding": {
@@ -10582,17 +10588,17 @@
 			"integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
 		},
 		"@babel/core": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.7.tgz",
-			"integrity": "sha512-djHlEfFHnSnTAcPb7dATbiM5HxGOP98+3JLBZtjRb5I7RXrw7kFRoG2dXM8cm3H+o11A8IFH/uprmJpwFynRNQ==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+			"integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.17.7",
 				"@babel/helper-compilation-targets": "^7.17.7",
 				"@babel/helper-module-transforms": "^7.17.7",
-				"@babel/helpers": "^7.17.7",
-				"@babel/parser": "^7.17.7",
+				"@babel/helpers": "^7.17.8",
+				"@babel/parser": "^7.17.8",
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.17.3",
 				"@babel/types": "^7.17.0",
@@ -10890,9 +10896,9 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.7.tgz",
-			"integrity": "sha512-TKsj9NkjJfTBxM7Phfy7kv6yYc4ZcOo+AaWGqQOKTPDOmcGkIFb5xNA746eKisQkm4yavUYh4InYM9S+VnO01w==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+			"integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
 			"requires": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.17.3",
@@ -10910,9 +10916,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
-			"integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA=="
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+			"integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.7",
@@ -11366,12 +11372,12 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
-			"integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz",
+			"integrity": "sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==",
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.16.7",
-				"@babel/helper-module-transforms": "^7.16.7",
+				"@babel/helper-module-transforms": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
@@ -11692,9 +11698,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-			"integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+			"version": "7.17.8",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+			"integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -12349,9 +12355,9 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.18",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
-			"integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
+			"version": "7.1.19",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
+			"integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -13040,9 +13046,9 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001317",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz",
-			"integrity": "sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ=="
+			"version": "1.0.30001319",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+			"integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw=="
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -13352,9 +13358,9 @@
 			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -13444,9 +13450,9 @@
 			},
 			"dependencies": {
 				"domhandler": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-					"integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+					"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
 					"dev": true,
 					"requires": {
 						"domelementtype": "^2.2.0"
@@ -13496,9 +13502,9 @@
 			},
 			"dependencies": {
 				"domhandler": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-					"integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+					"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
 					"dev": true,
 					"requires": {
 						"domelementtype": "^2.2.0"
@@ -13507,9 +13513,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.86",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.86.tgz",
-			"integrity": "sha512-EVTZ+igi8x63pK4bPuA95PXIs2b2Cowi3WQwI9f9qManLiZJOD1Lash1J3W4TvvcUCcIR4o/rgi9o8UicXSO+w=="
+			"version": "1.4.88",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz",
+			"integrity": "sha512-oA7mzccefkvTNi9u7DXmT0LqvhnOiN2BhSrKerta7HeUC1cLoIwtbf2wL+Ah2ozh5KQd3/1njrGrwDBXx6d14Q=="
 		},
 		"emittery": {
 			"version": "0.8.1",
@@ -13955,9 +13961,9 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "26.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
-			"integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.2.tgz",
+			"integrity": "sha512-1bXCoRODPkGN06n9KAMls4Jm0eyS+0Q/LWcIxhqWR2ycV0Z7lnx2c10idk4dtFIJY5xStgiIr5snC6/rxcXpbw==",
 			"requires": {
 				"@typescript-eslint/utils": "^5.10.0"
 			}
@@ -17390,17 +17396,17 @@
 			}
 		},
 		"string.prototype.matchall": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
-			"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+			"integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
-				"has-symbols": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"regexp.prototype.flags": "^1.3.1",
+				"regexp.prototype.flags": "^1.4.1",
 				"side-channel": "^1.0.4"
 			}
 		},


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._