### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2720,9 +2720,9 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.10",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
-			"integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A=="
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
 		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
@@ -4257,9 +4257,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.92",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-			"integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA=="
+			"version": "1.4.96",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.96.tgz",
+			"integrity": "sha512-DPNjvNGPabv6FcyjzLAN4C0psN/GgD9rSGvMTuv81SeXG/EX3mCz0wiw9N1tUEnfQXYCJi3H8M0oFPRziZh7rw=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -4462,9 +4462,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-			"integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+			"integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
 			"dependencies": {
 				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
@@ -8363,12 +8363,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
@@ -8936,9 +8936,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-			"integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
+			"integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -10027,9 +10027,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -12418,9 +12418,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.10",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
-			"integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A=="
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -13510,9 +13510,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.92",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-			"integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA=="
+			"version": "1.4.96",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.96.tgz",
+			"integrity": "sha512-DPNjvNGPabv6FcyjzLAN4C0psN/GgD9rSGvMTuv81SeXG/EX3mCz0wiw9N1tUEnfQXYCJi3H8M0oFPRziZh7rw=="
 		},
 		"emittery": {
 			"version": "0.8.1",
@@ -13660,9 +13660,9 @@
 			}
 		},
 		"eslint": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-			"integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+			"integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
 			"requires": {
 				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
@@ -16453,12 +16453,12 @@
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
 		"micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			}
 		},
 		"mime-db": {
@@ -16861,9 +16861,9 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
 		},
 		"prettier": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-			"integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
+			"integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A=="
 		},
 		"pretty-format": {
 			"version": "27.5.1",
@@ -17671,9 +17671,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
 		},
 		"unbox-primitive": {
 			"version": "1.0.1",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._