### PR TITLE
feat: add jsx/tsx files to default jest babel setup

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -38,7 +38,7 @@ const jestConfig = {
 };
 
 if (useBuiltInBabelConfig) {
-	jestConfig.transform = { '^.+\\.[jt]s$': here('./babel-transform') };
+	jestConfig.transform = { '^.+\\.[jt]sx?$': here('./babel-transform') };
 }
 
 module.exports = jestConfig;


### PR DESCRIPTION
We need to transpile `.tsx` files in tests if we want to be able to use jsx syntax with typescript.