### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3736,9 +3736,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001400",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-			"integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
+			"version": "1.0.30001406",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+			"integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4066,11 +4066,11 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.1.tgz",
-			"integrity": "sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.2.tgz",
+			"integrity": "sha512-TxfyECD4smdn3/CjWxczVtJqVLEEC2up7/82t7vC0AzNogr+4nQ8vyF7abxAuTXWvjTClSbvGhU0RgqA4ToQaQ==",
 			"dependencies": {
-				"browserslist": "^4.21.3"
+				"browserslist": "^4.21.4"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4185,9 +4185,9 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
-			"integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg=="
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
+			"integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw=="
 		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
@@ -4369,9 +4369,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
-			"integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ=="
+			"version": "1.4.254",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+			"integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -13729,9 +13729,9 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001400",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-			"integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA=="
+			"version": "1.0.30001406",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+			"integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg=="
 		},
 		"ccount": {
 			"version": "1.1.0",
@@ -13961,11 +13961,11 @@
 			}
 		},
 		"core-js-compat": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.1.tgz",
-			"integrity": "sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.2.tgz",
+			"integrity": "sha512-TxfyECD4smdn3/CjWxczVtJqVLEEC2up7/82t7vC0AzNogr+4nQ8vyF7abxAuTXWvjTClSbvGhU0RgqA4ToQaQ==",
 			"requires": {
-				"browserslist": "^4.21.3"
+				"browserslist": "^4.21.4"
 			}
 		},
 		"cosmiconfig": {
@@ -14042,9 +14042,9 @@
 			}
 		},
 		"decimal.js": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
-			"integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg=="
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
+			"integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw=="
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -14176,9 +14176,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
-			"integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ=="
+			"version": "1.4.254",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+			"integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q=="
 		},
 		"emittery": {
 			"version": "0.8.1",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._