### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,9 +2779,9 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
-			"integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.2.tgz",
+			"integrity": "sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==",
 			"dependencies": {
 				"@babel/types": "^7.3.0"
 			}
@@ -2835,9 +2835,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
+			"version": "18.7.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
+			"integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -2850,9 +2850,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"node_modules/@types/prettier": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
-			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+			"integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow=="
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
@@ -3165,12 +3165,12 @@
 			}
 		},
 		"node_modules/anchor-markdown-header": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
-			"integrity": "sha512-AmikqcK15r3q99hPvTa1na9n3eLkW0uE+RL9BZMSgwYalQeDnNXbYrN06BIcBPfGlmsGIE2jvkuvl/x0hyPF5Q==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz",
+			"integrity": "sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==",
 			"dev": true,
 			"dependencies": {
-				"emoji-regex": "~6.1.0"
+				"emoji-regex": "~10.1.0"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -3736,9 +3736,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001409",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-			"integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
+			"version": "1.0.30001412",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+			"integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4066,9 +4066,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.25.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.2.tgz",
-			"integrity": "sha512-TxfyECD4smdn3/CjWxczVtJqVLEEC2up7/82t7vC0AzNogr+4nQ8vyF7abxAuTXWvjTClSbvGhU0RgqA4ToQaQ==",
+			"version": "3.25.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.3.tgz",
+			"integrity": "sha512-xVtYpJQ5grszDHEUU9O7XbjjcZ0ccX3LgQsyqSvTnjX97ZqEgn9F5srmrwwwMtbKzDllyFPL+O+2OFMl1lU4TQ==",
 			"dependencies": {
 				"browserslist": "^4.21.4"
 			},
@@ -4258,13 +4258,13 @@
 			}
 		},
 		"node_modules/doctoc": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.2.0.tgz",
-			"integrity": "sha512-PtiyaS+S3kcMbpx6x2V0S+PeDKisxmjEFnZsuYkkj4Lh3ObozJuuYh9dM4+sX02Ouuty8RF2LOCnIbpu/hWy/A==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.2.1.tgz",
+			"integrity": "sha512-qNJ1gsuo7hH40vlXTVVrADm6pdg30bns/Mo7Nv1SxuXSM1bwF9b4xQ40a6EFT/L1cI+Yylbyi8MPI4G4y7XJzQ==",
 			"dev": true,
 			"dependencies": {
 				"@textlint/markdown-to-ast": "^12.1.1",
-				"anchor-markdown-header": "^0.5.7",
+				"anchor-markdown-header": "^0.6.0",
 				"htmlparser2": "^7.2.0",
 				"minimist": "^1.2.6",
 				"underscore": "^1.13.2",
@@ -4369,9 +4369,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.257",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
-			"integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A=="
+			"version": "1.4.262",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz",
+			"integrity": "sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -4385,9 +4385,9 @@
 			}
 		},
 		"node_modules/emoji-regex": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
-			"integrity": "sha512-73/zxHTjP2N2FQf0J5ngNjxP9LqG2krUshxYaowI8HxZQsiL2pYJc3k9/O93fc5/lCSkZv+bQ5Esk6k6msiSvg==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+			"integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
 			"dev": true
 		},
 		"node_modules/enquirer": {
@@ -4435,21 +4435,21 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
+			"integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.2",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.6",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
@@ -4459,6 +4459,7 @@
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -4579,12 +4580,12 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.23.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+			"version": "8.24.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
 			"dependencies": {
 				"@eslint/eslintrc": "^1.3.2",
-				"@humanwhocodes/config-array": "^0.10.4",
+				"@humanwhocodes/config-array": "^0.10.5",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
@@ -6142,9 +6143,9 @@
 			}
 		},
 		"node_modules/is-callable": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
-			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -9962,9 +9963,9 @@
 			}
 		},
 		"node_modules/rxjs": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-			"integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+			"integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -9973,6 +9974,19 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -10637,9 +10651,9 @@
 			}
 		},
 		"node_modules/underscore": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-			"integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
 			"dev": true
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -13029,9 +13043,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
-			"integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.2.tgz",
+			"integrity": "sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==",
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
@@ -13085,9 +13099,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "18.7.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
+			"version": "18.7.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
+			"integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -13100,9 +13114,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@types/prettier": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
-			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+			"integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow=="
 		},
 		"@types/stack-utils": {
 			"version": "2.0.1",
@@ -13297,12 +13311,12 @@
 			}
 		},
 		"anchor-markdown-header": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
-			"integrity": "sha512-AmikqcK15r3q99hPvTa1na9n3eLkW0uE+RL9BZMSgwYalQeDnNXbYrN06BIcBPfGlmsGIE2jvkuvl/x0hyPF5Q==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz",
+			"integrity": "sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==",
 			"dev": true,
 			"requires": {
-				"emoji-regex": "~6.1.0"
+				"emoji-regex": "~10.1.0"
 			}
 		},
 		"ansi-colors": {
@@ -13724,9 +13738,9 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001409",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-			"integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ=="
+			"version": "1.0.30001412",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+			"integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA=="
 		},
 		"ccount": {
 			"version": "1.1.0",
@@ -13956,9 +13970,9 @@
 			}
 		},
 		"core-js-compat": {
-			"version": "3.25.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.2.tgz",
-			"integrity": "sha512-TxfyECD4smdn3/CjWxczVtJqVLEEC2up7/82t7vC0AzNogr+4nQ8vyF7abxAuTXWvjTClSbvGhU0RgqA4ToQaQ==",
+			"version": "3.25.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.3.tgz",
+			"integrity": "sha512-xVtYpJQ5grszDHEUU9O7XbjjcZ0ccX3LgQsyqSvTnjX97ZqEgn9F5srmrwwwMtbKzDllyFPL+O+2OFMl1lU4TQ==",
 			"requires": {
 				"browserslist": "^4.21.4"
 			}
@@ -14089,13 +14103,13 @@
 			}
 		},
 		"doctoc": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.2.0.tgz",
-			"integrity": "sha512-PtiyaS+S3kcMbpx6x2V0S+PeDKisxmjEFnZsuYkkj4Lh3ObozJuuYh9dM4+sX02Ouuty8RF2LOCnIbpu/hWy/A==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.2.1.tgz",
+			"integrity": "sha512-qNJ1gsuo7hH40vlXTVVrADm6pdg30bns/Mo7Nv1SxuXSM1bwF9b4xQ40a6EFT/L1cI+Yylbyi8MPI4G4y7XJzQ==",
 			"dev": true,
 			"requires": {
 				"@textlint/markdown-to-ast": "^12.1.1",
-				"anchor-markdown-header": "^0.5.7",
+				"anchor-markdown-header": "^0.6.0",
 				"htmlparser2": "^7.2.0",
 				"minimist": "^1.2.6",
 				"underscore": "^1.13.2",
@@ -14171,9 +14185,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.257",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
-			"integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A=="
+			"version": "1.4.262",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz",
+			"integrity": "sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw=="
 		},
 		"emittery": {
 			"version": "0.8.1",
@@ -14181,9 +14195,9 @@
 			"integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg=="
 		},
 		"emoji-regex": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
-			"integrity": "sha512-73/zxHTjP2N2FQf0J5ngNjxP9LqG2krUshxYaowI8HxZQsiL2pYJc3k9/O93fc5/lCSkZv+bQ5Esk6k6msiSvg==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+			"integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
 			"dev": true
 		},
 		"enquirer": {
@@ -14219,21 +14233,21 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
+			"integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.2",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.6",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
@@ -14243,6 +14257,7 @@
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -14326,12 +14341,12 @@
 			}
 		},
 		"eslint": {
-			"version": "8.23.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+			"version": "8.24.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
 			"requires": {
 				"@eslint/eslintrc": "^1.3.2",
-				"@humanwhocodes/config-array": "^0.10.4",
+				"@humanwhocodes/config-array": "^0.10.5",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
@@ -15402,9 +15417,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
-			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
 		},
 		"is-core-module": {
 			"version": "2.10.0",
@@ -18132,9 +18147,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-			"integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+			"integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
 			"requires": {
 				"tslib": "^2.1.0"
 			}
@@ -18143,6 +18158,16 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			}
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -18651,9 +18676,9 @@
 			}
 		},
 		"underscore": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-			"integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
 			"dev": true
 		},
 		"unicode-canonical-property-names-ecmascript": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._