### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1870,9 +1870,9 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-			"integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -2710,18 +2710,18 @@
 			}
 		},
 		"node_modules/@textlint/ast-node-types": {
-			"version": "12.2.2",
-			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.2.2.tgz",
-			"integrity": "sha512-VQAXUSGdmEajHXrMxeM9ZTS8UBJSVB0ghJFHpFfqYKlcDsjIqClSmTprY6521HoCoSLoUIGBxTC3jQyUMJFIWw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.3.0.tgz",
+			"integrity": "sha512-ke5hlKy/xZ/vQt6j+h4k9GradJPDsV3FKsUqWpCpF/X8qWCU2zM4e1SMUAFjoUcLuF9in+eXIQ71Qm/AdjjkZQ==",
 			"dev": true
 		},
 		"node_modules/@textlint/markdown-to-ast": {
-			"version": "12.2.3",
-			"resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.2.3.tgz",
-			"integrity": "sha512-omZqcZV1Q8t9K0IKvlHNIdTV3SKNaS2P5qkbTjzDj7PuTuvG20JFqL9Naiwwi9ty3NzTzq+W8lLG3H2HgX0WvA==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.3.0.tgz",
+			"integrity": "sha512-gyLVU5WTJOIYJlGOPixENCzoj8SC4mpDkB+ADVFoqWCK4AOiZOHxDCH69g2AQQWKJYNmw7is4ZnyKA6q+OCPAw==",
 			"dev": true,
 			"dependencies": {
-				"@textlint/ast-node-types": "^12.2.2",
+				"@textlint/ast-node-types": "^12.3.0",
 				"debug": "^4.3.4",
 				"mdast-util-gfm-autolink-literal": "^0.1.3",
 				"remark-footnotes": "^3.0.0",
@@ -4077,9 +4077,9 @@
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.0.tgz",
-			"integrity": "sha512-spN2H4E/wocMML7XtbKuqttHHM+zbF3bAdl9mT4/iyFaF33bowQGjxiWNWyvUJGH9F+hTgnhWziiLtwu3oC/Qg==",
+			"version": "3.27.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.1.tgz",
+			"integrity": "sha512-Dg91JFeCDA17FKnneN7oCMz4BkQ4TcffkgHP4OWwp9yx3pi7ubqMDXXSacfNak1PQqjc95skyt+YBLHQJnkJwA==",
 			"dependencies": {
 				"browserslist": "^4.21.4"
 			},
@@ -4592,11 +4592,11 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
-			"integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
+			"version": "8.31.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+			"integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.4.0",
+				"@eslint/eslintrc": "^1.4.1",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -4834,9 +4834,9 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "27.1.7",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.7.tgz",
-			"integrity": "sha512-0QVzf+og4YI1Qr3UoprkqqhezAZjFffdi62b0IurkCXMqPtRW84/UT4CKsYT80h/D82LA9avjO/80Ou1LdgbaQ==",
+			"version": "27.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.0.tgz",
+			"integrity": "sha512-KGIYtelk4rIhKocxRKUEeX+kJ0ZCab/CiSgS8BMcKD7AY7YxXhlg/d51oF5jq2rOrtuJEDYWRwXD95l6l2vtrA==",
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -5338,9 +5338,9 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
 		"node_modules/fastq": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-			"integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
@@ -6874,9 +6874,15 @@
 			}
 		},
 		"node_modules/jest-config/node_modules/ci-info": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+			"integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
 			"engines": {
 				"node": ">=8"
 			}
@@ -7985,9 +7991,15 @@
 			}
 		},
 		"node_modules/jest-util/node_modules/ci-info": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+			"integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
 			"engines": {
 				"node": ">=8"
 			}
@@ -8332,9 +8344,9 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
 		},
 		"node_modules/json5": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-			"integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -10618,9 +10630,9 @@
 			}
 		},
 		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dependencies": {
 				"minimist": "^1.2.0"
 			},
@@ -12435,9 +12447,9 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
 		},
 		"@eslint/eslintrc": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-			"integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -13056,18 +13068,18 @@
 			}
 		},
 		"@textlint/ast-node-types": {
-			"version": "12.2.2",
-			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.2.2.tgz",
-			"integrity": "sha512-VQAXUSGdmEajHXrMxeM9ZTS8UBJSVB0ghJFHpFfqYKlcDsjIqClSmTprY6521HoCoSLoUIGBxTC3jQyUMJFIWw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.3.0.tgz",
+			"integrity": "sha512-ke5hlKy/xZ/vQt6j+h4k9GradJPDsV3FKsUqWpCpF/X8qWCU2zM4e1SMUAFjoUcLuF9in+eXIQ71Qm/AdjjkZQ==",
 			"dev": true
 		},
 		"@textlint/markdown-to-ast": {
-			"version": "12.2.3",
-			"resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.2.3.tgz",
-			"integrity": "sha512-omZqcZV1Q8t9K0IKvlHNIdTV3SKNaS2P5qkbTjzDj7PuTuvG20JFqL9Naiwwi9ty3NzTzq+W8lLG3H2HgX0WvA==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.3.0.tgz",
+			"integrity": "sha512-gyLVU5WTJOIYJlGOPixENCzoj8SC4mpDkB+ADVFoqWCK4AOiZOHxDCH69g2AQQWKJYNmw7is4ZnyKA6q+OCPAw==",
 			"dev": true,
 			"requires": {
-				"@textlint/ast-node-types": "^12.2.2",
+				"@textlint/ast-node-types": "^12.3.0",
 				"debug": "^4.3.4",
 				"mdast-util-gfm-autolink-literal": "^0.1.3",
 				"remark-footnotes": "^3.0.0",
@@ -14057,9 +14069,9 @@
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
 		},
 		"core-js-compat": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.0.tgz",
-			"integrity": "sha512-spN2H4E/wocMML7XtbKuqttHHM+zbF3bAdl9mT4/iyFaF33bowQGjxiWNWyvUJGH9F+hTgnhWziiLtwu3oC/Qg==",
+			"version": "3.27.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.1.tgz",
+			"integrity": "sha512-Dg91JFeCDA17FKnneN7oCMz4BkQ4TcffkgHP4OWwp9yx3pi7ubqMDXXSacfNak1PQqjc95skyt+YBLHQJnkJwA==",
 			"requires": {
 				"browserslist": "^4.21.4"
 			}
@@ -14429,11 +14441,11 @@
 			}
 		},
 		"eslint": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
-			"integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
+			"version": "8.31.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+			"integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
 			"requires": {
-				"@eslint/eslintrc": "^1.4.0",
+				"@eslint/eslintrc": "^1.4.1",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -14730,9 +14742,9 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "27.1.7",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.7.tgz",
-			"integrity": "sha512-0QVzf+og4YI1Qr3UoprkqqhezAZjFffdi62b0IurkCXMqPtRW84/UT4CKsYT80h/D82LA9avjO/80Ou1LdgbaQ==",
+			"version": "27.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.0.tgz",
+			"integrity": "sha512-KGIYtelk4rIhKocxRKUEeX+kJ0ZCab/CiSgS8BMcKD7AY7YxXhlg/d51oF5jq2rOrtuJEDYWRwXD95l6l2vtrA==",
 			"requires": {
 				"@typescript-eslint/utils": "^5.10.0"
 			}
@@ -14941,9 +14953,9 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
 		"fastq": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-			"integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"requires": {
 				"reusify": "^1.0.4"
 			}
@@ -15993,9 +16005,9 @@
 					}
 				},
 				"ci-info": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-					"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog=="
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+					"integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
 				},
 				"color-convert": {
 					"version": "2.0.1",
@@ -16809,9 +16821,9 @@
 					}
 				},
 				"ci-info": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-					"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog=="
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+					"integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
 				},
 				"color-convert": {
 					"version": "2.0.1",
@@ -17062,9 +17074,9 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
 		},
 		"json5": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-			"integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
 		},
 		"jsx-ast-utils": {
 			"version": "3.3.3",
@@ -18726,9 +18738,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"requires": {
 						"minimist": "^1.2.0"
 					}


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._