### PR TITLE
chore: change of ownership from developer-productivity to partner-enablement-and-apps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # The last matching pattern takes precedence.
 # https://help.github.com/articles/about-codeowners/
 
-*    @Tradeshift/developer-productivity @Tradeshift/ci-workers
+*    @Tradeshift/partner-enablement-and-apps @Tradeshift/ci-workers

--- a/Repofile
+++ b/Repofile
@@ -1,5 +1,5 @@
 {
     "maintainers": [
-        "developer-productivity"
+        "partner-enablement-and-apps"
     ]
 }

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -12,4 +12,4 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: developer-productivity
+  owner: partner-enablement-and-apps


### PR DESCRIPTION
This PR changes the ownership of this repo to partner-enablement-and-apps, as the developer productivity team doesn't exist anymore.