### PR TITLE
fix: add jest env var to avoid adding it in every repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
 		"extends": "./src/config/eslintrc",
 		"rules": {
 			"jest/no-jest-import": 0
+		},
+		"env": {
+			"jest": true
 		}
 	},
 	"prettier": "./src/config/prettierrc",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Add jest env var to detect `jest/globals` in the consuming repos.

<!-- Why are these changes necessary? -->
**Why**: Avoid adding something in every consuming repo.

<!-- How were these changes implemented? -->
**How**: Add one env var to package.json -> eslintConfig

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
