### PR TITLE
FIX - add npm prepare script so husky v8 is setup and stops throwing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ dist
 .DS_Store
 .eslintcache
 .idea
+.husky
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"lint": "node src lint",
 		"format": "node src format",
 		"validate": "node src validate",
-		"precommit": "node src precommit"
+		"precommit": "node src precommit",
+		"prepare": "husky install"
 	},
 	"files": [
 		"dist",

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -7,7 +7,7 @@ module.exports = {
 	'**/*.+(js|jsx|json|less|css|ts|tsx)': [
 		`${kcdScripts} format`,
 		`${kcdScripts} lint`,
-		`${kcdScripts} test --findRelatedTests`,
+		`${kcdScripts} test --findRelatedTests --passWithNoTests`,
 	],
 	'README.md': doctoc ? [`${doctoc} --maxlevel 2 --notitle`] : [],
 };


### PR DESCRIPTION
This may be a bit of trial & error, but I'm attempting to fix the tradeshift-scripts for our team. Open to better suggestions, but this works if I add the prepare statement to my team's repo. I want to test if this would work for everyone without having to update individual repos... we are all receiving errors like below since the version upgrade from 5.2.5 to 5.2.6 where husky was upgraded from ^4.0.0 to ^8.0.0

```
git commit -m 'blablabla'
npm ERR! could not determine executable to run

npm ERR! A complete log of this run can be found in: /Users/cole.yonkee/.npm/_logs/2023-08-31T13_41_49_321Z-debug-0.log
```
and the corresponding npm log contains:
```
0 verbose cli /Users/cole.yonkee/.nvm/versions/node/v18.17.1/bin/node /Users/cole.yonkee/.nvm/versions/node/v18.17.1/lib/node_modules/npm/bin/npm-cli.js
1 info using npm@9.6.7
2 info using node@v18.17.1
3 timing npm:load:whichnode Completed in 1ms
4 timing config:load:defaults Completed in 1ms
5 timing config:load:file:/Users/cole.yonkee/.nvm/versions/node/v18.17.1/lib/node_modules/npm/npmrc Completed in 0ms
6 timing config:load:builtin Completed in 0ms
7 timing config:load:cli Completed in 1ms
8 timing config:load:env Completed in 0ms
9 timing config:load:file:/Users/cole.yonkee/Projects/cash/cash-metrics/.npmrc Completed in 1ms
10 timing config:load:project Completed in 3ms
11 timing config:load:file:/Users/cole.yonkee/.npmrc Completed in 0ms
12 timing config:load:user Completed in 0ms
13 timing config:load:file:/Users/cole.yonkee/.nvm/versions/node/v18.17.1/etc/npmrc Completed in 0ms
14 timing config:load:global Completed in 0ms
15 timing config:load:setEnvs Completed in 1ms
16 timing config:load Completed in 9ms
17 timing npm:load:configload Completed in 10ms
18 timing npm:load:mkdirpcache Completed in 0ms
19 timing npm:load:mkdirplogs Completed in 0ms
20 verbose title npm exec husky-run pre-commit
21 verbose argv "exec" "--yes" "false" "--" "husky-run" "pre-commit"
22 timing npm:load:setTitle Completed in 19ms
23 timing config:load:flatten Completed in 4ms
24 timing npm:load:display Completed in 4ms
25 verbose logfile logs-max:10 dir:/Users/cole.yonkee/.npm/_logs/2023-08-31T13_41_49_321Z-
26 verbose logfile /Users/cole.yonkee/.npm/_logs/2023-08-31T13_41_49_321Z-debug-0.log
27 timing npm:load:logFile Completed in 9ms
28 timing npm:load:timers Completed in 0ms
29 timing npm:load:configScope Completed in 0ms
30 timing npm:load Completed in 43ms
31 timing arborist:ctor Completed in 1ms
32 silly logfile start cleaning logs, removing 1 files
33 silly logfile done cleaning log files
34 timing arborist:ctor Completed in 0ms
35 http fetch GET 200 https://registry.npmjs.org/husky-run 573ms (cache revalidated)
36 timing command:exec Completed in 856ms
37 verbose stack Error: could not determine executable to run
37 verbose stack     at getBinFromManifest (/Users/cole.yonkee/.nvm/versions/node/v18.17.1/lib/node_modules/npm/node_modules/libnpmexec/lib/get-bin-from-manifest.js:17:23)
37 verbose stack     at exec (/Users/cole.yonkee/.nvm/versions/node/v18.17.1/lib/node_modules/npm/node_modules/libnpmexec/lib/index.js:188:15)
37 verbose stack     at async module.exports (/Users/cole.yonkee/.nvm/versions/node/v18.17.1/lib/node_modules/npm/lib/cli.js:89:5)
38 verbose pkgid husky-run@0.0.0
39 verbose cwd /Users/cole.yonkee/Projects/cash/cash-metrics
40 verbose Darwin 22.6.0
41 verbose node v18.17.1
42 verbose npm  v9.6.7
43 error could not determine executable to run
44 verbose exit 1
45 timing npm Completed in 1157ms
46 verbose code 1
47 error A complete log of this run can be found in: /Users/cole.yonkee/.npm/_logs/2023-08-31T13_41_49_321Z-debug-0.log

```

Others on Github filed similar issue: https://github.com/npm/cli/issues/1845, so Husky provided a migration CLI in their docs: https://typicode.github.io/husky/migrating-from-v4.html which suggests doing the following:
```
npm install husky@latest --save-dev \
  && npx husky-init \
  && npm exec -- github:typicode/husky-4-to-8 --remove-v4-config
```
"husky init sets up Git hooks and updates your package.json scripts (you may want to commit your changes to package.json before running husky init).

husky-4-to-8 creates hooks based on your husky v4 config. If --remove-v4-config is passed, previous config will be deleted (recommended)."

**Checklist**:

- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
