### PR TITLE
fix(jest): transpile axios by default

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -25,7 +25,11 @@ const jestConfig = {
 	collectCoverageFrom: ['src/**/*.[jt]s?(x)'],
 	coveragePathIgnorePatterns: [...ignores, 'src/(umd|cjs|esm)-entry.[jt]s$'],
 	coverageReporters: ['text', 'cobertura', 'lcov', 'json'],
-	transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+	transformIgnorePatterns: [
+		'[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$',
+		'node_modules/(?!axios)/', // transpile axios because it has es6 modules post v1
+		// https://github.com/axios/axios/issues/5101#issuecomment-1275242123
+	],
 	reporters: ['default', [require.resolve('jest-junit'), junitConfig]],
 	coverageThreshold: {
 		global: {


### PR DESCRIPTION
This PR is to have axios be transpiled by default because the latest versions of axios (> v1) are modules instead of commonjs.

https://github.com/axios/axios/issues/5101#issuecomment-1275242123