### PR TITLE
fix(jest): use axios cjs

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -25,11 +25,11 @@ const jestConfig = {
 	collectCoverageFrom: ['src/**/*.[jt]s?(x)'],
 	coveragePathIgnorePatterns: [...ignores, 'src/(umd|cjs|esm)-entry.[jt]s$'],
 	coverageReporters: ['text', 'cobertura', 'lcov', 'json'],
-	transformIgnorePatterns: [
-		'[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$',
-		'node_modules/(?!axios)/', // transpile axios because it has es6 modules post v1
-		// https://github.com/axios/axios/issues/5101#issuecomment-1275242123
-	],
+	transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
+	moduleNameMapper: {
+		// https://github.com/axios/axios/issues/5101
+		axios: 'axios/dist/node/axios.cjs',
+	},
 	reporters: ['default', [require.resolve('jest-junit'), junitConfig]],
 	coverageThreshold: {
 		global: {


### PR DESCRIPTION
Really by Landon Gavin

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Make jest use the browser/commonJS version of axios.

<!-- Why are these changes necessary? -->
**Why**:

Jest fails using the ES version of axios which has become the default export.

<!-- How were these changes implemented? -->
**How**:

[The same changes have been implemented in the v4 apps server](https://github.com/Tradeshift/Apps-Server/pull/1557/files#diff-5c3593d9fa78c7017db5c6bc91517638b8b867321574d609ec1176605ea2698e).

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
