### PR TITLE
fix(deps): downgrade read-pkg-up to v7 to avoid ERR_REQUIRE_ESM error

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>Tradeshift/renovate-config:automerge-all"
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["local>Tradeshift/renovate-config:automerge-all"],
+	"packageRules": [
+		{
+			"matchPackageNames": ["read-pkg-up"],
+			"allowedVersions": "<8"
+		}
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 				"lodash.merge": "^4.6.2",
 				"mkdirp": "^3.0.1",
 				"prettier": "^3.1.1",
-				"read-pkg-up": "^10.1.0",
+				"read-pkg-up": "^7.0.1",
 				"resolve": "^1.22.8",
 				"rimraf": "^5.0.5",
 				"semver": "^7.5.4",
@@ -3166,9 +3166,9 @@
 			"integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
 		},
 		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.0",
@@ -6427,23 +6427,9 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-			"integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-			"integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-			"engines": {
-				"node": "14 || >=16.14"
-			}
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
 		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
@@ -9676,17 +9662,22 @@
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
 		"node_modules/normalize-package-data": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-			"integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/normalize-path": {
@@ -10217,179 +10208,49 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
 		},
 		"node_modules/read-pkg": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
-			"integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 			"dependencies": {
-				"@types/normalize-package-data": "^2.4.1",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^7.0.0",
-				"type-fest": "^4.2.0"
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
 			},
 			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/read-pkg-up": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
-			"integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
 			"dependencies": {
-				"find-up": "^6.3.0",
-				"read-pkg": "^8.1.0",
-				"type-fest": "^4.2.0"
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/find-up": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-			"dependencies": {
-				"locate-path": "^7.1.0",
-				"path-exists": "^5.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/locate-path": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-			"dependencies": {
-				"p-locate": "^6.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-			"dependencies": {
-				"yocto-queue": "^1.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/p-locate": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-			"dependencies": {
-				"p-limit": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/path-exists": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/read-pkg-up/node_modules/type-fest": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.2.tgz",
-			"integrity": "sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-			"integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/read-pkg/node_modules/lines-and-columns": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-			"integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			}
-		},
-		"node_modules/read-pkg/node_modules/parse-json": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
-			"integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
-			"dependencies": {
-				"@babel/code-frame": "^7.21.4",
-				"error-ex": "^1.3.2",
-				"json-parse-even-better-errors": "^3.0.0",
-				"lines-and-columns": "^2.0.3",
-				"type-fest": "^3.8.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-			"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.2.tgz",
-			"integrity": "sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
 			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/readdirp": {
@@ -14133,9 +13994,9 @@
 			"integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
 		},
 		"@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
 		},
 		"@types/parse-json": {
 			"version": "4.0.0",
@@ -16378,19 +16239,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-			"integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-			"requires": {
-				"lru-cache": "^10.0.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-					"integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag=="
-				}
-			}
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
 		},
 		"html-escaper": {
 			"version": "2.0.2",
@@ -18636,14 +18487,21 @@
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
 		"normalize-package-data": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-			"integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"requires": {
-				"hosted-git-info": "^7.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+				}
 			}
 		},
 		"normalize-path": {
@@ -18997,109 +18855,37 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
 		},
 		"read-pkg": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
-			"integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 			"requires": {
-				"@types/normalize-package-data": "^2.4.1",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^7.0.0",
-				"type-fest": "^4.2.0"
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
 			},
 			"dependencies": {
-				"json-parse-even-better-errors": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-					"integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA=="
-				},
-				"lines-and-columns": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-					"integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A=="
-				},
-				"parse-json": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
-					"integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
-					"requires": {
-						"@babel/code-frame": "^7.21.4",
-						"error-ex": "^1.3.2",
-						"json-parse-even-better-errors": "^3.0.0",
-						"lines-and-columns": "^2.0.3",
-						"type-fest": "^3.8.0"
-					},
-					"dependencies": {
-						"type-fest": {
-							"version": "3.13.1",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-							"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
-						}
-					}
-				},
 				"type-fest": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.2.tgz",
-					"integrity": "sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ=="
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
 				}
 			}
 		},
 		"read-pkg-up": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
-			"integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
 			"requires": {
-				"find-up": "^6.3.0",
-				"read-pkg": "^8.1.0",
-				"type-fest": "^4.2.0"
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-					"requires": {
-						"locate-path": "^7.1.0",
-						"path-exists": "^5.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-					"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-					"requires": {
-						"p-locate": "^6.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-					"requires": {
-						"yocto-queue": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-					"requires": {
-						"p-limit": "^4.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-					"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
-				},
 				"type-fest": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.2.tgz",
-					"integrity": "sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ=="
-				},
-				"yocto-queue": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"lodash.merge": "^4.6.2",
 		"mkdirp": "^3.0.1",
 		"prettier": "^3.1.1",
-		"read-pkg-up": "^10.1.0",
+		"read-pkg-up": "^7.0.1",
 		"resolve": "^1.22.8",
 		"rimraf": "^5.0.5",
 		"semver": "^7.5.4",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**npm run validate would exit with an `[ERR_REQUIRE_ESM]: require() of ES Module not supported` error because the `read-pkg-up` package has migrated to ESM and this is commonJS. Downgrading `read-pkg-up` to v7 fixes this and does not cause vulnerability issues.**:

<!-- Why are these changes necessary? -->
tradeshift-scripts has failed to publish new releases since [read-pkg-up was updated from v7 to v10](https://github.com/Tradeshift/tradeshift-scripts/commit/6ce3be80a621688c7068bf36ea976a634f40dde0).

<!-- How were these changes implemented? -->
Changes were done by running `npm i read-pkg-up@7`. Additionally, the `renovate` config has been updated to restrict  `read-pkg-up` versions to <8.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
