### PR TITLE
fix: update axios entry in jest moduleNameMapper

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -8,7 +8,7 @@ const junitConfig = hasPkgProp('jest-junit')
 	? {}
 	: {
 			outputDirectory: fromRoot('build/junit'),
-	  };
+		};
 
 const ignores = [
 	'/node_modules/',
@@ -25,11 +25,10 @@ const jestConfig = {
 	collectCoverageFrom: ['src/**/*.[jt]s?(x)'],
 	coveragePathIgnorePatterns: [...ignores, 'src/(umd|cjs|esm)-entry.[jt]s$'],
 	coverageReporters: ['text', 'cobertura', 'lcov', 'json'],
-	transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\]'],
-	moduleNameMapper: {
-		// https://github.com/axios/axios/issues/5101
-		axios: 'axios/dist/node/axios.cjs',
-	},
+	transformIgnorePatterns: [
+		'[/\\\\]node_modules[/\\\\]',
+		'node_modules/(?!@tradeshift/tradeshift-mui)',
+	],
 	reporters: ['default', [require.resolve('jest-junit'), junitConfig]],
 	coverageThreshold: {
 		global: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

1. Remove jest module name mapping of axios.
2. Add @tradeshift/tradeshift-mui to jest transformIgnorePatterns.

<!-- Why are these changes necessary? -->
**Why**:

1. Updating Jest to 29 (in an upcoming major version of @tradeshiftv4) requires this.
2. This deprecates the need for mocking the library in every single test file.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
